### PR TITLE
chore: add bitpacking to bench + compression example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ lz4_flex = { version = "0.11", default-features = false }
 smallvec = "1.11.2"
 time = { version = "0.3.30", default-features = false }
 pco = "0.1.3"
+bitpacking = "0.9.2"

--- a/crates/uwheel/Cargo.toml
+++ b/crates/uwheel/Cargo.toml
@@ -15,7 +15,7 @@ targets = []
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["std", "all", "avg", "sum", "min", "max", "smallvec"]
+default = ["std", "all", "avg", "sum", "min", "max"]
 std = ["serde?/std"]
 all = []
 avg = []
@@ -26,11 +26,11 @@ top_n = ["dep:hashbrown"]
 simd = ["dep:multiversion"]
 sync = ["dep:parking_lot", "std"]
 serde = [
-  "dep:serde",
-  "dep:serde-big-array",
-  "parking_lot?/serde",
-  "hashbrown?/serde",
-  "uwheel-stats?/serde",
+    "dep:serde",
+    "dep:serde-big-array",
+    "parking_lot?/serde",
+    "hashbrown?/serde",
+    "uwheel-stats?/serde",
 ]
 profiler = ["dep:uwheel-stats", "prettytable-rs", "std"]
 timer = []
@@ -50,13 +50,14 @@ smallvec = { workspace = true, optional = true }
 
 [dev-dependencies]
 time = { workspace = true, default-features = false, features = [
-  "macros",
-  "parsing",
+    "macros",
+    "parsing",
 ] }
 fastrand.workspace = true
 rand.workspace = true
 criterion.workspace = true
 pco.workspace = true
+bitpacking.workspace = true
 
 
 [[bench]]

--- a/crates/uwheel/src/wheels/read/aggregation/mod.rs
+++ b/crates/uwheel/src/wheels/read/aggregation/mod.rs
@@ -567,7 +567,7 @@ mod tests {
                 WheelConf::new(HOUR_TICK_MS, 24).with_retention_policy(RetentionPolicy::Keep);
             let mut wheel = Wheel::<U32SumAggregator>::new(conf);
 
-            for i in 0..120 {
+            for i in 0..150 {
                 wheel.insert_slot(WheelSlot::with_total(Some(i)));
                 compressed_wheel.insert_slot(WheelSlot::with_total(Some(i)));
 

--- a/examples/compression/Cargo.toml
+++ b/examples/compression/Cargo.toml
@@ -9,6 +9,7 @@ readme.workspace = true
 
 [dependencies]
 uwheel.workspace = true
+bitpacking.workspace = true
 fastrand.workspace = true
 clap.workspace = true
 pco.workspace = true

--- a/examples/compression/README.md
+++ b/examples/compression/README.md
@@ -1,7 +1,7 @@
 Here is an example showing how to configure an Aggregator with compression support.
 
-This example uses [pco](https://github.com/mwlon/pcodec) to compress aggregates at the seconds granularity and prints the wheel size of compression vs. non-compression.
+This example uses [pco](https://github.com/mwlon/pcodec) and [bitpacking](https://docs.rs/bitpacking/latest/bitpacking/) to compress aggregates at the seconds granularity and prints the wheel size of compression vs. non-compression.
 
 ```sh
-cargo run --release -p compression 
+cargo run --release -p compression
 ```

--- a/examples/compression/src/main.rs
+++ b/examples/compression/src/main.rs
@@ -1,3 +1,4 @@
+use bitpacking::{BitPacker, BitPacker4x};
 use clap::Parser;
 use uwheel::{
     aggregator::{sum::U32SumAggregator, Compression},
@@ -9,6 +10,8 @@ use uwheel::{
     Conf,
     RwWheel,
 };
+
+pub const CHUNK_SIZE: usize = BitPacker4x::BLOCK_LEN;
 
 #[derive(Clone, Debug, Default)]
 pub struct PcoSumAggregator;
@@ -47,11 +50,67 @@ impl Aggregator for PcoSumAggregator {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BitPackingSumAggregator;
+
+impl Aggregator for BitPackingSumAggregator {
+    const IDENTITY: Self::PartialAggregate = 0;
+
+    type Input = u32;
+    type PartialAggregate = u32;
+    type MutablePartialAggregate = u32;
+    type Aggregate = u32;
+
+    fn lift(input: Self::Input) -> Self::MutablePartialAggregate {
+        input
+    }
+    fn combine_mutable(mutable: &mut Self::MutablePartialAggregate, input: Self::Input) {
+        *mutable += input
+    }
+    fn freeze(a: Self::MutablePartialAggregate) -> Self::PartialAggregate {
+        a
+    }
+
+    fn combine(a: Self::PartialAggregate, b: Self::PartialAggregate) -> Self::PartialAggregate {
+        a + b
+    }
+    fn lower(a: Self::PartialAggregate) -> Self::Aggregate {
+        a
+    }
+
+    fn compression() -> Option<Compression<Self::PartialAggregate>> {
+        let compressor = |slice: &[u32]| {
+            let bitpacker = BitPacker4x::new();
+            let num_bits = bitpacker.num_bits(slice);
+            let mut compressed = vec![0u8; BitPacker4x::BLOCK_LEN * 4];
+            let compressed_len = bitpacker.compress(slice, &mut compressed[..], num_bits);
+
+            // 1 bit for metadata + compressed data
+            let mut result = Vec::with_capacity(1 + compressed_len);
+            // Prepend metadata
+            result.push(num_bits);
+            // Append compressed data
+            result.extend_from_slice(&compressed[..compressed_len]);
+
+            result
+        };
+        let decompressor = |bytes: &[u8]| {
+            let bit_packer = BitPacker4x::new();
+            // Extract num bits metadata
+            let bits = bytes[0];
+            // Decompress data
+            let mut decompressed = vec![0u32; BitPacker4x::BLOCK_LEN];
+            bit_packer.decompress(&bytes[1..], &mut decompressed, bits);
+
+            decompressed
+        };
+        Some(Compression::new(compressor, decompressor))
+    }
+}
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(short, long, value_parser, default_value_t = 60)]
-    chunk_size: usize,
     #[clap(short, long, value_parser, default_value_t = 3600)]
     seconds: usize,
 }
@@ -59,29 +118,49 @@ struct Args {
 fn main() {
     let args = Args::parse();
     let seconds = args.seconds;
+
+    // Pco Configuration
     let mut pco_haw_conf = HawConf::default();
     pco_haw_conf
         .seconds
         .set_retention_policy(RetentionPolicy::Keep);
-    let chunk_size = args.chunk_size;
     pco_haw_conf
         .seconds
-        .set_data_layout(DataLayout::Compressed(chunk_size));
+        .set_data_layout(DataLayout::Compressed(CHUNK_SIZE));
 
     let pco_wheel: RwWheel<PcoSumAggregator> =
         RwWheel::with_conf(Conf::default().with_haw_conf(pco_haw_conf));
 
+    // Bitpacking Configuration
+    let mut bitpacking_haw_conf = HawConf::default();
+    bitpacking_haw_conf
+        .seconds
+        .set_retention_policy(RetentionPolicy::Keep);
+    bitpacking_haw_conf
+        .seconds
+        .set_data_layout(DataLayout::Compressed(CHUNK_SIZE));
+
+    let bitpacking_wheel: RwWheel<BitPackingSumAggregator> =
+        RwWheel::with_conf(Conf::default().with_haw_conf(bitpacking_haw_conf));
+
+    // Regular Configuration
     let mut haw_conf = HawConf::default();
     haw_conf.seconds.set_retention_policy(RetentionPolicy::Keep);
 
     let wheel: RwWheel<U32SumAggregator> =
         RwWheel::with_conf(Conf::default().with_haw_conf(haw_conf));
 
+    // Generate random deltas
     let deltas: Vec<Option<u32>> = (0..seconds).map(|_| Some(fastrand::u32(1..1000))).collect();
 
     pco_wheel.read().delta_advance(deltas.clone());
+    bitpacking_wheel.read().delta_advance(deltas.clone());
     wheel.read().delta_advance(deltas);
 
     println!("U32SumAggregator Size {} bytes", wheel.size_bytes());
+    println!(
+        "BitpackingAggregator Size {} bytes",
+        bitpacking_wheel.size_bytes()
+    );
     println!("PcoSumAggregator Size {} bytes", pco_wheel.size_bytes());
 }


### PR DESCRIPTION
**Performance vs non bitpacking:**

<img width="766" alt="Screenshot 2024-07-04 at 11 06 14" src="https://github.com/uwheel/uwheel/assets/11488530/0f0547d0-5a17-4059-8da5-0af73425ab23">

**Space reduction:**

<img width="909" alt="Screenshot 2024-07-04 at 11 06 37" src="https://github.com/uwheel/uwheel/assets/11488530/e1b9d470-2397-494e-8342-26f77b426742">
