### PR TITLE
add session windowing + rework window API

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -114,8 +114,9 @@ An aggregate wheel supports three possible data layouts that are configurable pe
 
 µWheel supports the following queries:
 
-* ``window(range, slide)``
-    * Installs a periodic streaming window aggregation query.
+* ``window(window)``
+    * Installs a streaming window aggregation query.
+    * µWheel supports Tumbling, Sliding, and Session Windows.
 * ``combine_range(start, end) -> Aggregate``
     * Combines the time range into a final aggregate.
 * ``interval(duration) -> Aggregate``
@@ -140,8 +141,7 @@ The image below illustrates a flow chart of the query optimizer which aims to se
 
 ## Streaming Window Aggregation
 
-µWheel uses the Pairs stream slicing technique internally and if a window is installed it continously build pairs.
-Pairs are managed internally by a circular-based window aggregator that implements the following functions:
+µWheel supports ``Tumbling``, ``Sliding``, and ``Session`` windows. For Tumbling and Sliding, µWheel uses the Pairs stream slicing technique internally and if a window is installed it continously build pairs. Pairs are managed internally by a circular-based window aggregator that implements the following functions:
 
 - ``push(p: Pair)`` Pushes a pair into the back.
 - ``compute()`` Computes the current window.

--- a/README.md
+++ b/README.md
@@ -115,11 +115,7 @@ let mut watermark = 1699488000000;
 let mut wheel: RwWheel<U32SumAggregator> = RwWheel::new(watermark);
 
 // Install a Sliding Window Aggregation Query (results are produced when we advance the wheel).
-wheel.window(
-    Window::default()
-        .with_range(30.minutes())
-        .with_slide(10.minutes()),
-);
+wheel.window(Window::sliding(30.minutes(), 10.minutes()));
 
 // Simulate ingestion and fill the wheel with 1 hour of aggregates (3600 seconds).
 for _ in 0..3600 {
@@ -129,8 +125,8 @@ for _ in 0..3600 {
     watermark += 1000;
 
     // Print the result if any window is triggered
-    for (ts, window) in wheel.advance_to(watermark) {
-        println!("Window fired at {} with result {}", ts, window);
+    for window in wheel.advance_to(watermark) {
+        println!("Window fired {:#?}", window);
     }
 }
 // Explore historical data - The low watermark is now 2023-11-09 01:00:00

--- a/crates/uwheel-demo/src/app.rs
+++ b/crates/uwheel-demo/src/app.rs
@@ -1106,7 +1106,7 @@ impl eframe::App for TemplateApp {
                 ui.text_edit_singleline(end_time);
             });
 
-            ui.label(&format!("Result: {}", query_result));
+            ui.label(format!("Result: {}", query_result));
             ui.horizontal(|ui| {
                 if ui.button("Run").clicked() {
                     let start = NaiveDateTime::parse_from_str(

--- a/crates/uwheel/src/duration.rs
+++ b/crates/uwheel/src/duration.rs
@@ -45,6 +45,7 @@ const fn expect_failed(message: &str) -> ! {
 /// perform niche value optimization.
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) enum Padding {
     #[allow(clippy::missing_docs_in_private_items)]
     Optimize,
@@ -58,6 +59,7 @@ impl Default for Padding {
 
 /// A span of time with nanosecond precision.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Duration {
     /// Number of whole seconds.
     seconds: i64,

--- a/crates/uwheel/src/lib.rs
+++ b/crates/uwheel/src/lib.rs
@@ -72,7 +72,7 @@ pub use wheels::{
     Conf,
     RwWheel,
 };
-pub use window::Window;
+pub use window::{Window, WindowAggregate};
 
 #[doc(hidden)]
 pub use time::OffsetDateTime;

--- a/crates/uwheel/src/wheels/mod.rs
+++ b/crates/uwheel/src/wheels/mod.rs
@@ -16,7 +16,7 @@ mod stats;
 #[allow(dead_code)]
 mod timer;
 
-use crate::{aggregator::Aggregator, duration::Duration, Entry};
+use crate::{aggregator::Aggregator, duration::Duration, window::WindowAggregate, Entry};
 use core::fmt::Debug;
 use write::DEFAULT_WRITE_AHEAD_SLOTS;
 
@@ -24,10 +24,7 @@ pub use read::{DAYS, HOURS, MINUTES, SECONDS, WEEKS, YEARS};
 pub use wheel_ext::WheelExt;
 pub use write::WriterWheel;
 
-use self::read::{
-    hierarchical::{HawConf, WindowAggregate},
-    ReaderWheel,
-};
+use self::read::{hierarchical::HawConf, ReaderWheel};
 
 use crate::window::Window;
 
@@ -138,7 +135,7 @@ where
     /// use uwheel::{Window, aggregator::sum::U32SumAggregator, RwWheel, NumericalDuration};
     ///
     /// // Define a window query
-    /// let window = Window::default().with_range(10.seconds()).with_slide(3.seconds());
+    /// let window = Window::sliding(10.seconds(), 3.seconds());
     /// // Initialize a Reader-Writer Wheel and install the window
     /// let mut wheel: RwWheel<U32SumAggregator> = RwWheel::new(0);
     /// wheel.window(window);

--- a/crates/uwheel/src/wheels/read/hierarchical.rs
+++ b/crates/uwheel/src/wheels/read/hierarchical.rs
@@ -729,7 +729,7 @@ where
         let (ref mut state, ref mut aggregator) = manager.aggregator.session_as_mut();
         if let Some(partial) = delta {
             if !state.has_active_session() {
-                state.activate_session(self.watermark - 1000);
+                state.activate_session(self.watermark.saturating_sub(1000)); // subtract watermark by 1 tick to align correctly.
             }
             // Aggregate the partial into the session
             aggregator.aggregate_session(partial);
@@ -747,7 +747,7 @@ where
 
                     // SAFETY: safe to unwrap since we checked if there is an active session
                     let window_start_ms = state.reset().unwrap();
-                    let window_end_ms = self.watermark.saturating_sub(1000);
+                    let window_end_ms = self.watermark.saturating_sub(1000); // subtract watermark by 1 tick to align correctly.
 
                     windows.push(WindowAggregate {
                         window_start_ms,

--- a/crates/uwheel/src/wheels/read/mod.rs
+++ b/crates/uwheel/src/wheels/read/mod.rs
@@ -12,13 +12,20 @@ pub(crate) mod stats;
 #[cfg(feature = "timer")]
 use crate::wheels::timer::{TimerAction, TimerError};
 
-use crate::{cfg_not_sync, cfg_sync, delta::DeltaState, duration::Duration, WheelRange};
+use crate::{
+    cfg_not_sync,
+    cfg_sync,
+    delta::DeltaState,
+    duration::Duration,
+    window::WindowAggregate,
+    WheelRange,
+};
 pub use hierarchical::{Haw, DAYS, HOURS, MINUTES, SECONDS, WEEKS, YEARS};
 pub use plan::ExecutionPlan;
 
 use crate::aggregator::Aggregator;
 
-use self::hierarchical::{HawConf, WindowAggregate};
+use self::hierarchical::HawConf;
 use crate::window::Window;
 
 use super::write::WriterWheel;
@@ -142,7 +149,7 @@ where
 
     #[doc(hidden)]
     pub fn window(&mut self, window: Window) {
-        self.inner.write().window(window.range, window.slide);
+        self.inner.write().window(window);
     }
 
     /// Advance the watermark of the wheel by the given [Duration]

--- a/crates/uwheel/src/window/mod.rs
+++ b/crates/uwheel/src/window/mod.rs
@@ -26,6 +26,15 @@ pub struct WindowAggregate<T> {
 }
 
 /// Different window variants supported by µWheel
+///
+/// # Example
+///
+/// ```
+/// use uwheel::{Window, RwWheel, aggregator::sum::U32SumAggregator, NumericalDuration};
+///
+/// let mut wheel: RwWheel<U32SumAggregator> = RwWheel::new(0);
+/// wheel.window(Window::tumbling(10.seconds()));
+/// ```
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[derive(Copy, Clone, Debug)]
 pub enum Window {
@@ -99,9 +108,9 @@ impl Window {
 pub struct WindowManager<A: Aggregator> {
     pub(crate) aggregator: WindowAggregator<A>,
     pub(crate) window: Window,
-    //pub(crate) state: State,
 }
 impl<A: Aggregator> WindowManager<A> {
+    /// Creates a new window manager with the given watermark and window type
     pub fn new(watermark: u64, window: Window) -> Self {
         let to_ms = |d: Duration| d.whole_milliseconds() as usize;
 

--- a/crates/uwheel/src/window/state.rs
+++ b/crates/uwheel/src/window/state.rs
@@ -94,7 +94,6 @@ impl SessionState {
 
     pub fn is_inactive(&self) -> bool {
         self.inactive_period >= self.session_gap
-        //self.inactive_period.checked_add(Duration::SECOND).unwrap() >= self.session_gap
     }
 
     /// Bumps the current inactive period by the given duration

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -14,11 +14,7 @@ fn main() {
     let mut wheel: RwWheel<U32SumAggregator> = RwWheel::new(watermark);
 
     // Install a Sliding Window Aggregation Query (results are produced when we advance the wheel).
-    wheel.window(
-        Window::default()
-            .with_range(30.minutes())
-            .with_slide(10.minutes()),
-    );
+    wheel.window(Window::sliding(30.minutes(), 10.minutes()));
 
     // Simulate ingestion and fill the wheel with 1 hour of aggregates (3600 seconds).
     for _ in 0..3600 {
@@ -28,8 +24,8 @@ fn main() {
         watermark += 1000;
 
         // Print the result if any window is triggered
-        for (ts, window) in wheel.advance_to(watermark) {
-            println!("Window fired at {} with result {}", ts, window);
+        for window in wheel.advance_to(watermark) {
+            println!("Window fired {:#?}", window);
         }
     }
     // Explore historical data - The low watermark is now 2023-11-09 01:00:00

--- a/examples/window/src/main.rs
+++ b/examples/window/src/main.rs
@@ -4,11 +4,7 @@ fn main() {
     let mut wheel: RwWheel<U64SumAggregator> = RwWheel::new(0);
 
     // Install window
-    wheel.window(
-        Window::default()
-            .with_range(10.seconds())
-            .with_slide(3.seconds()),
-    );
+    wheel.window(Window::sliding(10.seconds(), 3.seconds()));
 
     // insert an entry per second
     for i in 1..=22 {


### PR DESCRIPTION
This PR adds session windowing support to µWheel and also reworks the window API to be more user-friendly and extensible "Breaking Change" 

```rust
pub enum Window {
    /// A tumbling window with a fixed range
    Tumbling {
        range: Duration,
    },
    /// A sliding window with a fixed range and slide
    Sliding {
        range: Duration,
        slide: Duration,
    },
    /// A session window with a fixed timeout
    Session {
        timeout: Duration,
    },
}
```